### PR TITLE
Added warning, information, and format timestamp

### DIFF
--- a/src/server/data_storage.adb
+++ b/src/server/data_storage.adb
@@ -9,11 +9,11 @@
 ---------------------------------------------------------------------------
 
 -- TODO: Remove dependency on Ada.Text_IO. Use a real logger.
-with Ada.Text_IO;
 with Postgresql;
+with Server_Logger;
 
-use Ada.Text_IO;
 use Postgresql;
+use Server_Logger;
 
 
 package body Data_Storage is
@@ -22,14 +22,14 @@ package body Data_Storage is
    begin
       -- TODO: Database connectivity information should come from a configuration file.
       Postgresql.Connect("localhost", 5432, "ThumperServer", "thumper", "rabbitsfoot");
-      Put_Line("Connected to the Database.");
+      Write_Information("Connected to the Database.");
    end Initialize;
 
 
    procedure Shutdown is
    begin
       Postgresql.Disconnect;
-      Put_Line("Disconnected From the Database");
+      Write_Information("Disconnected From the Database.");
    end Shutdown;
 
 

--- a/src/server/server_logger.adb
+++ b/src/server/server_logger.adb
@@ -10,12 +10,43 @@
 pragma SPARK_Mode(Off);
 
 with Ada.Text_IO;
+with Ada.Calendar;
 
 package body Server_Logger is
 
+   function Format_Timestamp return String is
+      Time_Of_Day : constant Ada.Calendar.Time := Ada.Calendar.Clock;
+      Year_Time : constant String := Integer'Image(Ada.Calendar.Year(Time_Of_Day));
+      Month_Time : constant String := Integer'Image(Ada.Calendar.Month(Time_Of_Day));
+      Day_Time : constant String := Integer'Image(Ada.Calendar.Day(Time_Of_Day));
+      Seconds_Time : constant Integer := Integer(Ada.Calendar.Seconds(Time_Of_Day));
+      Seconds_Hour : constant Integer := Integer(Seconds_Time / 3600);
+      Seconds_Minute : constant Integer := (Seconds_Time - (Seconds_Hour * 3600)) / 60;
+      Seconds_Second : constant Integer := Seconds_Time - (Seconds_Hour * 3600) - (Seconds_Minute * 60);
+      Hour_String : constant String := Integer'Image(Seconds_Hour);
+      Minute_String : constant String := Integer'Image(Seconds_Minute);
+      Second_String : constant String := Integer'Image(Seconds_Second);
+      Full_Seconds_String : constant String := Hour_String(2 .. Hour_String'Last) & ":" & Minute_String(2 .. Minute_String'Last) & ":" & Second_String(2 .. Second_String'Last);
+   begin
+      return Year_Time(2 .. Year_Time'Last) & "-" & Month_Time(2 .. Month_Time'Last) & "-" & Day_Time(2 .. Day_Time'Last) & " " & Full_Seconds_String;
+   end Format_Timestamp;
+
    procedure Write_Error(Message : in String) is
    begin
-      Ada.Text_IO.Put_Line("*** ERROR: " & Message);
+      Ada.Text_IO.Put_Line(Format_Timestamp & " *** ERROR: " & Message);
    end Write_Error;
+
+   procedure Write_Information(Message : in String) is
+   begin
+      Ada.Text_IO.Put_Line(Format_Timestamp & " *** INFORMATION: " & Message);
+   end Write_Information;
+
+   procedure Write_Warning(Message : in String) is
+   begin
+      Ada.Text_IO.Put_Line(Format_Timestamp & " *** WARNING: " & Message);
+   end Write_Warning;
+
+
+
 
 end Server_Logger;

--- a/src/server/server_logger.ads
+++ b/src/server/server_logger.ads
@@ -18,4 +18,11 @@ is
    procedure Write_Error(Message : in String)
      with Global => (Output => Log_Stream);
 
+   procedure Write_Information(Message : in String)
+     with Global => (Output => Log_Stream);
+
+   procedure Write_Warning(Message : in String)
+     with Global => (Output => Log_Stream);
+
+
 end Server_Logger;


### PR DESCRIPTION
Format_Timestamp takes data from Ada.Calender.Time, splits it up into readable segments, and returns it as a properly formatted timestamp. This timestamp is displayed when calling Write_Error, Write_Information, and Write_Warning. data_storage.adb now uses these write commands to display messages.